### PR TITLE
feat: implement crawler link extraction

### DIFF
--- a/crawler.py
+++ b/crawler.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from collections import deque
+from typing import List, Set
+from urllib.parse import urljoin, urlparse
+
+import requests
+from bs4 import BeautifulSoup
+
+
+NON_HTML_EXTENSIONS = {
+    '.jpg', '.jpeg', '.png', '.gif', '.svg', '.css', '.js', '.pdf',
+    '.zip', '.tar', '.gz', '.mp4', '.mp3', '.woff', '.woff2'
+}
+
+
+def _is_html_url(url: str) -> bool:
+    """Return True if URL points to an HTML page based on its extension."""
+    path = urlparse(url).path
+    if not path or path.endswith('/'):
+        return True
+    ext = path[path.rfind('.'):]
+    return ext.lower() in {'', '.html', '.htm'}
+
+
+def get_all_links(base_url: str) -> List[str]:
+    """Crawl ``base_url`` and return all internal HTML links.
+
+    Args:
+        base_url: The starting URL of the documentation site.
+
+    Returns:
+        A sorted list of unique URLs belonging to the same domain as ``base_url``.
+    """
+    parsed_base = urlparse(base_url)
+    domain = parsed_base.netloc
+    scheme = parsed_base.scheme
+
+    visited: Set[str] = set()
+    queue: deque[str] = deque([base_url])
+
+    while queue:
+        current_url = queue.popleft()
+        if current_url in visited:
+            continue
+        visited.add(current_url)
+
+        try:
+            response = requests.get(current_url)
+            response.raise_for_status()
+        except requests.RequestException:
+            continue
+
+        content_type = response.headers.get('Content-Type', '')
+        if 'text/html' not in content_type:
+            continue
+
+        soup = BeautifulSoup(response.text, 'html.parser')
+        for tag in soup.find_all('a', href=True):
+            href = tag['href']
+            if href.startswith('#'):
+                continue
+            next_url = urljoin(current_url, href)
+            parsed = urlparse(next_url)
+            if parsed.scheme not in {'http', 'https'}:
+                continue
+            if parsed.netloc != domain:
+                continue
+            if not _is_html_url(next_url):
+                continue
+            if next_url not in visited and next_url not in queue:
+                queue.append(next_url)
+
+    return sorted(visited)

--- a/tests/fixtures/test_crawler.py
+++ b/tests/fixtures/test_crawler.py
@@ -1,0 +1,97 @@
+from unittest.mock import Mock, patch
+import threading
+import http.server
+import socketserver
+import sys
+import functools
+from pathlib import Path
+
+import pytest
+
+ROOT_DIR = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT_DIR))
+
+from crawler import get_all_links
+
+
+class SilentHandler(http.server.SimpleHTTPRequestHandler):
+    def log_message(self, format, *args):  # noqa: D401  -- silence server logs
+        pass
+
+
+def run_server(directory, port=0):
+    handler = functools.partial(SilentHandler, directory=directory)
+    httpd = socketserver.TCPServer(('localhost', port), handler)
+    thread = threading.Thread(target=httpd.serve_forever)
+    thread.daemon = True
+    thread.start()
+    return httpd, httpd.server_address[1]
+
+
+def test_get_all_links_unit():
+    html_index = '<a href="/page1.html">1</a><a href="/page2.html">2</a>'
+    html_page1 = '<a href="/page2.html">2</a>'
+    html_page2 = '<a href="#anchor">A</a><a href="/page3.html">3</a>'
+    html_page3 = ''
+
+    responses = {
+        'https://example.com/': Mock(
+            status_code=200,
+            text=html_index,
+            headers={'Content-Type': 'text/html'}
+        ),
+        'https://example.com/page1.html': Mock(
+            status_code=200,
+            text=html_page1,
+            headers={'Content-Type': 'text/html'}
+        ),
+        'https://example.com/page2.html': Mock(
+            status_code=200,
+            text=html_page2,
+            headers={'Content-Type': 'text/html'}
+        ),
+        'https://example.com/page3.html': Mock(
+            status_code=200,
+            text=html_page3,
+            headers={'Content-Type': 'text/html'}
+        ),
+    }
+
+    def fake_get(url, *args, **kwargs):
+        return responses[url]
+
+    with patch('crawler.requests.get', side_effect=fake_get):
+        result = get_all_links('https://example.com/')
+
+    assert result == [
+        'https://example.com/',
+        'https://example.com/page1.html',
+        'https://example.com/page2.html',
+        'https://example.com/page3.html',
+    ]
+
+
+def test_get_all_links_integration(tmp_path):
+    (tmp_path / 'index.html').write_text(
+        '<a href="/page1.html">1</a><a href="/page2.html">2</a>'
+    )
+    (tmp_path / 'page1.html').write_text('<a href="/page2.html">2</a>')
+    (tmp_path / 'page2.html').write_text(
+        '<a href="#top">top</a><a href="/page3.html">3</a>'
+    )
+    (tmp_path / 'page3.html').write_text('')
+
+    server, port = run_server(str(tmp_path))
+    base_url = f'http://localhost:{port}/'
+    try:
+        result = get_all_links(base_url)
+    finally:
+        server.shutdown()
+        server.server_close()
+
+    assert result == [
+        base_url,
+        f'http://localhost:{port}/page1.html',
+        f'http://localhost:{port}/page2.html',
+        f'http://localhost:{port}/page3.html',
+    ]


### PR DESCRIPTION
## Summary
- add `get_all_links` crawler function to collect internal docs URLs
- create unit and integration tests for crawler

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684db02d40b483298ca71c15a82fd552