### PR TITLE
feat: add async PDF renderer

### DIFF
--- a/renderer.py
+++ b/renderer.py
@@ -1,0 +1,52 @@
+"""Utilities for rendering web pages to PDF using Playwright."""
+
+from __future__ import annotations
+
+import asyncio
+from urllib.parse import urlparse
+
+from playwright.async_api import async_playwright
+
+
+class RendererError(Exception):
+    """Raised when rendering a web page to PDF fails."""
+
+    pass
+
+
+async def render_to_pdf(url: str, output_path: str, timeout: int = 15000) -> bool:
+    """Render ``url`` into a PDF file.
+
+    Args:
+        url: HTTP/HTTPS URL to visit.
+        output_path: Destination PDF path. Must end with ``.pdf``.
+        timeout: Navigation timeout in milliseconds. Must be greater than 1000.
+
+    Returns:
+        ``True`` when the PDF was successfully written.
+
+    Raises:
+        RendererError: If arguments are invalid or rendering fails.
+    """
+
+    parsed = urlparse(url)
+    if parsed.scheme not in {"http", "https"}:
+        raise RendererError("URL must start with http or https")
+    if not output_path.lower().endswith(".pdf"):
+        raise RendererError("output_path must be a .pdf file")
+    if timeout <= 1000:
+        raise RendererError("timeout must be greater than 1000 ms")
+
+    try:
+        async with async_playwright() as p:
+            browser = await p.chromium.launch()
+            context = await browser.new_context(ignore_https_errors=True)
+            page = await context.new_page()
+            await page.goto(url, timeout=timeout)
+            await page.wait_for_load_state("networkidle")
+            await page.pdf(path=output_path)
+            await browser.close()
+    except Exception as exc:  # noqa: BLE001 -- convert to RendererError
+        raise RendererError(str(exc)) from exc
+
+    return True

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -1,0 +1,45 @@
+import sys
+from pathlib import Path
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from renderer import RendererError, render_to_pdf
+
+
+@patch("renderer.async_playwright")
+def test_render_to_pdf_unit(mock_playwright, tmp_path):
+    page = AsyncMock()
+    context = AsyncMock(new_page=AsyncMock(return_value=page))
+    browser = AsyncMock(new_context=AsyncMock(return_value=context))
+    browser_type = AsyncMock(launch=AsyncMock(return_value=browser))
+    mock_playwright_cm = AsyncMock()
+    mock_playwright_cm.__aenter__.return_value = MagicMock(chromium=browser_type)
+    mock_playwright.return_value = mock_playwright_cm
+
+    output = tmp_path / "test.pdf"
+    assert asyncio.run(render_to_pdf("https://example.com", str(output))) is True
+    page.goto.assert_called_with("https://example.com", timeout=15000)
+    page.wait_for_load_state.assert_called_with("networkidle")
+    page.pdf.assert_called_with(path=str(output))
+
+
+def test_render_to_pdf_invalid(tmp_path):
+    output = tmp_path / "test.pdf"
+    with pytest.raises(RendererError):
+        asyncio.run(render_to_pdf("ftp://example.com", str(output)))
+    with pytest.raises(RendererError):
+        asyncio.run(render_to_pdf("https://example.com", "out.txt"))
+    with pytest.raises(RendererError):
+        asyncio.run(render_to_pdf("https://example.com", str(output), timeout=500))
+
+
+def test_render_to_pdf_integration(tmp_path):
+    output = tmp_path / "page.pdf"
+    url = "https://docs.telegram-mini-apps.com"  # small static page
+    assert asyncio.run(render_to_pdf(url, str(output), timeout=20000)) is True
+    assert output.exists() and output.stat().st_size > 0


### PR DESCRIPTION
## Summary
- implement `RendererError` and `render_to_pdf`
- add unit and integration tests for renderer

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684db8cfc9448329a274c9597be3323f