### PR TITLE
feat: scaffold config, logging and orchestration

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
 import argparse
+import asyncio
+
+from config import load_config
+from main import run
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -10,7 +14,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--timeout",
         type=int,
-        default=15000,
+        default=load_config().timeout,
         help="Render timeout in milliseconds",
     )
     return parser
@@ -20,6 +24,11 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     return build_parser().parse_args(argv)
 
 
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    asyncio.run(run(args.url, args.output, timeout=args.timeout))
+    return 0
+
+
 if __name__ == "__main__":  # pragma: no cover - manual invocation only
-    args = parse_args()
-    print(f"URL: {args.url} -> {args.output} (timeout={args.timeout})")
+    raise SystemExit(main())

--- a/config.py
+++ b/config.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+
+DEFAULT_TIMEOUT = 15000
+
+
+@dataclass(slots=True)
+class Config:
+    """Application configuration loaded from environment variables."""
+
+    timeout: int = DEFAULT_TIMEOUT
+
+
+def load_config() -> Config:
+    """Load configuration from environment variables."""
+    timeout = int(os.environ.get("WEB2PDFBOOK_TIMEOUT", DEFAULT_TIMEOUT))
+    return Config(timeout=timeout)

--- a/logger.py
+++ b/logger.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import logging
+from logging import Logger
+
+from rich.logging import RichHandler
+
+
+def get_logger(name: str) -> Logger:
+    """Return a configured logger with rich output."""
+    logger = logging.getLogger(name)
+    if not logger.handlers:
+        handler = RichHandler(rich_tracebacks=True, show_time=False)
+        formatter = logging.Formatter(
+            "%(asctime)s %(name)s %(levelname)s: %(message)s",
+            datefmt="%H:%M:%S",
+        )
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+        logger.setLevel(logging.INFO)
+    return logger

--- a/main.py
+++ b/main.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import asyncio
+import os
+import tempfile
+
+from crawler import get_all_links
+from merger import merge_pdfs
+from renderer import render_to_pdf
+from logger import get_logger
+
+logger = get_logger(__name__)
+
+
+async def run(url: str, output: str, timeout: int = 15000) -> str:
+    """Crawl ``url`` and produce a merged PDF at ``output``."""
+    links = get_all_links(url)
+    pdf_paths: list[str] = []
+    with tempfile.TemporaryDirectory() as tmpdir:
+        for idx, link in enumerate(links):
+            dest = os.path.join(tmpdir, f"page{idx}.pdf")
+            await render_to_pdf(link, dest, timeout=timeout)
+            pdf_paths.append(dest)
+        merge_pdfs(pdf_paths, output)
+    logger.info("written %s", output)
+    return output

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,13 @@
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from config import load_config
+
+
+def test_load_config_env(monkeypatch):
+    monkeypatch.setenv("WEB2PDFBOOK_TIMEOUT", "9999")
+    cfg = load_config()
+    assert cfg.timeout == 9999

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,0 +1,16 @@
+import sys
+from pathlib import Path
+import logging
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from logger import get_logger
+
+
+def test_get_logger_reuses_instance():
+    logger1 = get_logger("sample")
+    logger2 = get_logger("sample")
+    assert logger1 is logger2
+    assert logger1.handlers
+    assert isinstance(logger1.handlers[0], logging.Handler)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,22 @@
+import sys
+from pathlib import Path
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from main import run
+
+
+@patch("main.merge_pdfs")
+@patch("main.render_to_pdf", new_callable=AsyncMock)
+@patch("main.get_all_links")
+def test_run_orchestrates(mock_get_links, mock_render, mock_merge, tmp_path):
+    mock_get_links.return_value = ["https://a", "https://b"]
+    out = tmp_path / "book.pdf"
+    asyncio.run(run("https://base", str(out), 1234))
+    mock_get_links.assert_called_once_with("https://base")
+    assert mock_render.await_count == 2
+    mock_merge.assert_called_once()
+    assert mock_merge.call_args.args[1] == str(out)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,12 @@
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from utils import ensure_pdf_extension
+
+
+def test_ensure_pdf_extension():
+    assert ensure_pdf_extension("file") == "file.pdf"
+    assert ensure_pdf_extension("doc.PDF") == "doc.PDF"

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+
+def ensure_pdf_extension(path: str) -> str:
+    """Return ``path`` with a ``.pdf`` extension if missing."""
+    if not path.lower().endswith(".pdf"):
+        return f"{path}.pdf"
+    return path


### PR DESCRIPTION
## Summary
- define `Config` loader
- implement structured `get_logger`
- add PDF helper util
- add `main.run` orchestrator
- default CLI timeout from config
- add unit tests for new modules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dbd99b1a08329b0fc674ba2c3e599