### PR TITLE
feat: enforce ruff and mypy via pre-commit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@ __pycache__/
 *.log
 *.pdf
 tests/__pycache__/
-
 docs/
+.mypy_cache/
+.ruff_cache/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,17 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.1.8
+    hooks:
+      - id: ruff
+      - id: ruff-format
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.6.1
+    hooks:
+      - id: mypy
+  - repo: local
+    hooks:
+      - id: pytest
+        name: pytest
+        entry: pytest --quiet
+        language: system
+        types: [python]

--- a/config.py
+++ b/config.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
 import os
+from dataclasses import dataclass
 
 # Utility configuration helpers
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,4 @@
+-r requirements.txt
+pre-commit
+ruff
+mypy

--- a/main.py
+++ b/main.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
-import asyncio
 import os
 import tempfile
 
 from crawler import get_all_links
+from logger import get_logger
 from merger import merge_pdfs
 from renderer import render_to_pdf
-from logger import get_logger
 
 logger = get_logger(__name__)
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,10 @@
+[mypy]
+python_version = 3.11
+ignore_missing_imports = True
+follow_imports = skip
+show_error_codes = True
+warn_unused_configs = True
+warn_redundant_casts = True
+warn_unused_ignores = True
+[mypy-requests.*]
+ignore_missing_imports = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,12 @@
+[tool.ruff]
+line-length = 88
+extend-select = ["I"]
+
+[tool.mypy]
+python_version = "3.11"
+warn_unused_configs = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+show_error_codes = true
+ignore_missing_imports = true
+follow_imports = "skip"

--- a/renderer.py
+++ b/renderer.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 from urllib.parse import urlparse
 
 from playwright.async_api import async_playwright

--- a/tests/fixtures/test_crawler.py
+++ b/tests/fixtures/test_crawler.py
@@ -1,17 +1,15 @@
-from unittest.mock import Mock, patch
-import threading
+import functools
 import http.server
 import socketserver
 import sys
-import functools
+import threading
 from pathlib import Path
-
-import pytest
+from unittest.mock import Mock, patch
 
 ROOT_DIR = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT_DIR))
 
-from crawler import get_all_links
+from crawler import get_all_links  # noqa: E402
 
 
 class SilentHandler(http.server.SimpleHTTPRequestHandler):
@@ -21,7 +19,7 @@ class SilentHandler(http.server.SimpleHTTPRequestHandler):
 
 def run_server(directory, port=0):
     handler = functools.partial(SilentHandler, directory=directory)
-    httpd = socketserver.TCPServer(('localhost', port), handler)
+    httpd = socketserver.TCPServer(("localhost", port), handler)
     thread = threading.Thread(target=httpd.serve_forever)
     thread.daemon = True
     thread.start()
@@ -35,72 +33,62 @@ def test_get_all_links_unit():
     )
     html_page1 = '<a href="/page2.html">2</a>'
     html_page2 = '<a href="#anchor">A</a><a href="/page3.html">3</a>'
-    html_page3 = ''
-    html_page_no_ext = ''
+    html_page3 = ""
+    html_page_no_ext = ""
 
     responses = {
-        'https://example.com/': Mock(
-            status_code=200,
-            text=html_index,
-            headers={'Content-Type': 'text/html'}
+        "https://example.com/": Mock(
+            status_code=200, text=html_index, headers={"Content-Type": "text/html"}
         ),
-        'https://example.com/page1.html': Mock(
-            status_code=200,
-            text=html_page1,
-            headers={'Content-Type': 'text/html'}
+        "https://example.com/page1.html": Mock(
+            status_code=200, text=html_page1, headers={"Content-Type": "text/html"}
         ),
-        'https://example.com/page2.html': Mock(
-            status_code=200,
-            text=html_page2,
-            headers={'Content-Type': 'text/html'}
+        "https://example.com/page2.html": Mock(
+            status_code=200, text=html_page2, headers={"Content-Type": "text/html"}
         ),
-        'https://example.com/page3.html': Mock(
-            status_code=200,
-            text=html_page3,
-            headers={'Content-Type': 'text/html'}
+        "https://example.com/page3.html": Mock(
+            status_code=200, text=html_page3, headers={"Content-Type": "text/html"}
         ),
-        'https://example.com/page': Mock(
+        "https://example.com/page": Mock(
             status_code=200,
             text=html_page_no_ext,
-            headers={'Content-Type': 'text/html'}
+            headers={"Content-Type": "text/html"},
         ),
-        'https://example.com/image.png': Mock(
-            status_code=200,
-            text='',
-            headers={'Content-Type': 'image/png'}
+        "https://example.com/image.png": Mock(
+            status_code=200, text="", headers={"Content-Type": "image/png"}
         ),
     }
 
     def fake_get(url, *args, **kwargs):
         return responses[url]
 
-    with patch('crawler.requests.get', side_effect=fake_get):
-        result = get_all_links('https://example.com/')
+    with patch("crawler.requests.get", side_effect=fake_get):
+        result = get_all_links("https://example.com/")
 
     assert result == [
-        'https://example.com/',
-        'https://example.com/page',
-        'https://example.com/page1.html',
-        'https://example.com/page2.html',
-        'https://example.com/page3.html',
+        "https://example.com/",
+        "https://example.com/page",
+        "https://example.com/page1.html",
+        "https://example.com/page2.html",
+        "https://example.com/page3.html",
     ]
 
 
 def test_get_all_links_integration(tmp_path):
-    (tmp_path / 'index.html').write_text(
+    (tmp_path / "index.html").write_text(
         '<a href="/page1.html">1</a><a href="/page2.html">2</a>'
         '<a href="/page">4</a><a href="/image.png">img</a>'
     )
-    (tmp_path / 'page1.html').write_text('<a href="/page2.html">2</a>')
-    (tmp_path / 'page2.html').write_text(
+    (tmp_path / "page1.html").write_text('<a href="/page2.html">2</a>')
+    (tmp_path / "page2.html").write_text(
         '<a href="#top">top</a><a href="/page3.html">3</a>'
     )
-    (tmp_path / 'page3.html').write_text('')
-    (tmp_path / 'page').write_text('')
-    (tmp_path / 'image.png').write_bytes(b'')
+    (tmp_path / "page3.html").write_text("")
+    (tmp_path / "page").write_text("")
+    (tmp_path / "image.png").write_bytes(b"")
 
     server, port = run_server(str(tmp_path))
-    base_url = f'http://localhost:{port}/'
+    base_url = f"http://localhost:{port}/"
     try:
         result = get_all_links(base_url)
     finally:
@@ -109,8 +97,8 @@ def test_get_all_links_integration(tmp_path):
 
     assert result == [
         base_url,
-        f'http://localhost:{port}/page',
-        f'http://localhost:{port}/page1.html',
-        f'http://localhost:{port}/page2.html',
-        f'http://localhost:{port}/page3.html',
+        f"http://localhost:{port}/page",
+        f"http://localhost:{port}/page1.html",
+        f"http://localhost:{port}/page2.html",
+        f"http://localhost:{port}/page3.html",
     ]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,11 +1,12 @@
 import sys
 from pathlib import Path
+
 ROOT_DIR = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT_DIR))
 
-import pytest
+import pytest  # noqa: E402
 
-from cli import parse_args
+from cli import parse_args  # noqa: E402
 
 
 def test_parse_args_valid():
@@ -25,4 +26,3 @@ def test_parse_args_valid():
 def test_parse_args_missing(argv):
     with pytest.raises(SystemExit):
         parse_args(argv)
-

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,7 +4,7 @@ from pathlib import Path
 ROOT_DIR = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT_DIR))
 
-from config import load_config
+from config import load_config  # noqa: E402
 
 
 def test_load_config_env(monkeypatch):

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,11 +1,11 @@
+import logging
 import sys
 from pathlib import Path
-import logging
 
 ROOT_DIR = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT_DIR))
 
-from logger import get_logger
+from logger import get_logger  # noqa: E402
 
 
 def test_get_logger_reuses_instance():

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,12 +1,12 @@
+import asyncio
 import sys
 from pathlib import Path
-import asyncio
 from unittest.mock import AsyncMock, patch
 
 ROOT_DIR = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT_DIR))
 
-from main import run
+from main import run  # noqa: E402
 
 
 @patch("main.merge_pdfs")

--- a/tests/test_merger.py
+++ b/tests/test_merger.py
@@ -1,12 +1,14 @@
+# ruff: noqa: I001
 import sys
 from pathlib import Path
+
+import pytest
+from PyPDF2 import PdfReader, PdfWriter
+
 ROOT_DIR = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT_DIR))
 
-from PyPDF2 import PdfReader, PdfWriter
-import pytest
-
-from merger import MergerError, merge_pdfs
+from merger import MergerError, merge_pdfs  # noqa: E402  # noqa: I001
 
 
 def create_pdf(path: Path) -> None:

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -1,15 +1,14 @@
+import asyncio
 import sys
 from pathlib import Path
-
-import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import pytest
+import pytest  # noqa: E402
 
 ROOT_DIR = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT_DIR))
 
-from renderer import RendererError, render_to_pdf
+from renderer import RendererError, render_to_pdf  # noqa: E402
 
 
 @patch("renderer.async_playwright")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,7 +4,7 @@ from pathlib import Path
 ROOT_DIR = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT_DIR))
 
-from utils import ensure_pdf_extension
+from utils import ensure_pdf_extension  # noqa: E402
 
 
 def test_ensure_pdf_extension():


### PR DESCRIPTION
## Summary
- add ruff, mypy and pytest pre-commit hooks
- configure ruff and mypy in `pyproject.toml` and `mypy.ini`
- add dev requirements for tooling install
- ignore cache directories
- update imports and tests for lint/typing compliance

## Testing
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_684e539538b0832996f53cb6de255814