### PR TITLE
feat(ci): add coverage reporting

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -18,5 +18,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-      - name: Run tests
-        run: pytest -q
+      - name: Run tests with coverage
+        run: |
+          python -m coverage run -m pytest -q
+          python -m coverage report --fail-under=85
+          python -m coverage html
+          coverage-badge -o coverage.svg -f

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ tests/__pycache__/
 docs/
 .mypy_cache/
 .ruff_cache/
+.coverage
+htmlcov/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# web2PDFbook
+
+This project converts web pages into a single PDF document.
+
+![Coverage](./coverage.svg)
+
+## Running tests
+
+```bash
+python -m coverage run -m pytest -q
+python -m coverage report
+python -m coverage html  # generates HTML report in htmlcov/
+```

--- a/coverage.svg
+++ b/coverage.svg
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="99" height="20">
+    <linearGradient id="b" x2="0" y2="100%">
+        <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+        <stop offset="1" stop-opacity=".1"/>
+    </linearGradient>
+    <mask id="a">
+        <rect width="99" height="20" rx="3" fill="#fff"/>
+    </mask>
+    <g mask="url(#a)">
+        <path fill="#555" d="M0 0h63v20H0z"/>
+        <path fill="#4c1" d="M63 0h36v20H63z"/>
+        <path fill="url(#b)" d="M0 0h99v20H0z"/>
+    </g>
+    <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+        <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
+        <text x="31.5" y="14">coverage</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">95%</text>
+        <text x="80" y="14">95%</text>
+    </g>
+</svg>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,3 +10,10 @@ warn_unused_ignores = true
 show_error_codes = true
 ignore_missing_imports = true
 follow_imports = "skip"
+
+[tool.coverage.run]
+branch = true
+source = ["."]
+
+[tool.coverage.report]
+fail_under = 85

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ playwright
 pytest
 tox
 rich
+coverage[toml]
+coverage-badge


### PR DESCRIPTION
## Summary
- integrate `coverage` using pyproject config
- generate coverage badge and html reports in CI
- show badge in README
- ignore `.coverage` and `htmlcov/`

## Testing
- `python -m coverage run -m pytest -q`
- `python -m coverage report --fail-under=85`
- `python -m coverage html`


------
https://chatgpt.com/codex/tasks/task_e_684e57dd180483299c6d493ed43d0ac5