### PR TITLE
feat(crawler): add extract_links usecase

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ pip install -r requirements.txt
 
 ## 🔄 How it works
 
-1. **Link crawling** – `crawler.get_all_links()` retrieves all internal HTML links starting from the base URL.
+1. **Link crawling** – `crawler.extract_links()` retrieves all internal HTML links starting from the base URL.
 2. **PDF rendering** – `renderer.render_to_pdf()` uses Playwright to save each page as a PDF.
 3. **Merging** – `merger.merge_pdfs()` merges the PDFs into a single document.
 

--- a/crawler/__init__.py
+++ b/crawler/__init__.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from .entity.crawl_result import CrawlResult
+from .usecase.extract_links import extract_links
+
+
+def get_all_links(base_url: str) -> list[str]:
+    """Backward-compatible wrapper for link extraction."""
+    return extract_links(base_url).links
+
+
+__all__ = ["CrawlResult", "extract_links", "get_all_links"]

--- a/crawler/entity/crawl_result.py
+++ b/crawler/entity/crawl_result.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(slots=True)
+class CrawlResult:
+    """Result of a crawl containing discovered links."""
+
+    links: list[str]

--- a/main.py
+++ b/main.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 import tempfile
 
-from crawler import get_all_links
+from crawler import extract_links
 from logger import get_logger
 from merger import merge_pdfs
 from renderer import PlaywrightRenderer, render_to_pdf
@@ -13,7 +13,8 @@ logger = get_logger(__name__)
 
 async def run(url: str, output: str, timeout: int = 15000) -> str:
     """Crawl ``url`` and produce a merged PDF at ``output``."""
-    links = get_all_links(url)
+    result = extract_links(url)
+    links = result.links
     renderer = PlaywrightRenderer()
     pdf_paths: list[str] = []
     with tempfile.TemporaryDirectory() as tmpdir:

--- a/renderer/__init__.py
+++ b/renderer/__init__.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from .entity.renderer import Renderer, RendererError
 from .adapter.playwright_renderer import PlaywrightRenderer
+from .entity.renderer import Renderer, RendererError
 from .usecase.render_to_pdf import render_to_pdf
 
 __all__ = [

--- a/renderer/adapter/playwright_renderer.py
+++ b/renderer/adapter/playwright_renderer.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from playwright.async_api import async_playwright
 
-from ..entity.renderer import Renderer, RendererError
+from ..entity.renderer import RendererError
 
 
 class PlaywrightRenderer:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -11,12 +11,12 @@ from main import run  # noqa: E402
 
 @patch("main.merge_pdfs")
 @patch("main.render_to_pdf", new_callable=AsyncMock)
-@patch("main.get_all_links")
-def test_run_orchestrates(mock_get_links, mock_render, mock_merge, tmp_path):
-    mock_get_links.return_value = ["https://a", "https://b"]
+@patch("main.extract_links")
+def test_run_orchestrates(mock_extract, mock_render, mock_merge, tmp_path):
+    mock_extract.return_value.links = ["https://a", "https://b"]
     out = tmp_path / "book.pdf"
     asyncio.run(run("https://base", str(out), 1234))
-    mock_get_links.assert_called_once_with("https://base")
+    mock_extract.assert_called_once_with("https://base")
     assert mock_render.await_count == 2
     mock_merge.assert_called_once()
     assert mock_merge.call_args.args[1] == str(out)

--- a/tests/usecase/test_render_to_pdf.py
+++ b/tests/usecase/test_render_to_pdf.py
@@ -8,8 +8,8 @@ import pytest
 ROOT_DIR = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT_DIR))
 
-from renderer import RendererError, PlaywrightRenderer
-from renderer.usecase.render_to_pdf import render_to_pdf
+from renderer import PlaywrightRenderer, RendererError  # noqa: E402
+from renderer.usecase.render_to_pdf import render_to_pdf  # noqa: E402
 
 
 @patch("renderer.adapter.playwright_renderer.async_playwright")


### PR DESCRIPTION
## Summary
- add `crawler` package with `extract_links` usecase
- wrap link extraction in new `CrawlResult` entity
- update `main.run` to use the new usecase
- move crawler tests to usecase layer and add error handling test
- tidy imports in renderer modules

## Testing
- `ruff check .`
- `mypy .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e649855b48329beadbf00320af81c