### PR TITLE
feat(cli): delegate to book_creator orchestrator

### DIFF
--- a/book_creator.py
+++ b/book_creator.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from crawler import extract_links
+from merger import PyPDF2Merger, merge_documents
+from renderer import PlaywrightRenderer, render_to_pdf
+from usecase import create_book
+
+
+async def run(url: str, output: str, timeout: int = 15000) -> str:
+    """Crawl ``url`` and produce a merged PDF at ``output``."""
+    renderer = PlaywrightRenderer()
+
+    async def render_page(u: str, dest: str, t: int) -> bool:
+        return await render_to_pdf(u, dest, timeout=t, renderer=renderer)
+
+    def merge_pdfs(paths: list[str], dest: str) -> bool:
+        return merge_documents(paths, dest, merger=PyPDF2Merger())
+
+    return await create_book(
+        url,
+        output,
+        timeout,
+        link_extractor=extract_links,
+        renderer=render_page,
+        merger=merge_pdfs,
+    )

--- a/cli.py
+++ b/cli.py
@@ -4,7 +4,7 @@ import argparse
 import asyncio
 
 from config import load_config
-from main import run
+from book_creator import run
 
 
 def build_parser() -> argparse.ArgumentParser:

--- a/main.py
+++ b/main.py
@@ -1,33 +1,15 @@
 from __future__ import annotations
 
-import os
-import tempfile
+import asyncio
+import sys
 
-from crawler import extract_links
-from logger import get_logger
-from merger import PyPDF2Merger, merge_documents
-from renderer import PlaywrightRenderer, render_to_pdf
-from usecase import create_book
-
-logger = get_logger(__name__)
+from book_creator import run
 
 
-async def run(url: str, output: str, timeout: int = 15000) -> str:
-    """Crawl ``url`` and produce a merged PDF at ``output``."""
-
-    renderer = PlaywrightRenderer()
-
-    async def render_page(u: str, dest: str, t: int) -> bool:
-        return await render_to_pdf(u, dest, timeout=t, renderer=renderer)
-
-    def merge_pdfs(paths: list[str], dest: str) -> bool:
-        return merge_documents(paths, dest, merger=PyPDF2Merger())
-
-    return await create_book(
-        url,
-        output,
-        timeout,
-        link_extractor=extract_links,
-        renderer=render_page,
-        merger=merge_pdfs,
-    )
+if __name__ == "__main__":  # pragma: no cover - manual invocation only
+    if len(sys.argv) < 3:
+        raise SystemExit("Usage: python main.py <url> <output> [timeout]")
+    url = sys.argv[1]
+    output = sys.argv[2]
+    timeout = int(sys.argv[3]) if len(sys.argv) > 3 else 15000
+    asyncio.run(run(url, output, timeout))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,8 +5,9 @@ ROOT_DIR = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT_DIR))
 
 import pytest  # noqa: E402
+from unittest.mock import AsyncMock, patch
 
-from cli import parse_args  # noqa: E402
+from cli import main, parse_args  # noqa: E402
 
 
 def test_parse_args_valid():
@@ -26,3 +27,12 @@ def test_parse_args_valid():
 def test_parse_args_missing(argv):
     with pytest.raises(SystemExit):
         parse_args(argv)
+
+
+@pytest.mark.asyncio
+@patch("cli.run", new_callable=AsyncMock)
+def test_main_invokes_runner(mock_run, tmp_path):
+    out = tmp_path / "book.pdf"
+    argv = ["https://example.com", str(out), "--timeout", "2000"]
+    assert main(argv) == 0
+    mock_run.assert_awaited_once_with("https://example.com", str(out), timeout=2000)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -6,12 +6,12 @@ from unittest.mock import AsyncMock, patch
 ROOT_DIR = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT_DIR))
 
-from main import run  # noqa: E402
+from book_creator import run  # noqa: E402
 
 
-@patch("main.merge_documents")
-@patch("main.render_to_pdf", new_callable=AsyncMock)
-@patch("main.extract_links")
+@patch("book_creator.merge_documents")
+@patch("book_creator.render_to_pdf", new_callable=AsyncMock)
+@patch("book_creator.extract_links")
 def test_run_orchestrates(mock_extract, mock_render, mock_merge, tmp_path):
     mock_extract.return_value.links = ["https://a", "https://b"]
     out = tmp_path / "book.pdf"


### PR DESCRIPTION
## Summary
- introduce `book_creator.run` orchestrator
- call orchestrator from CLI and simplify `main.py`
- test CLI runner invocation
- adapt tests to import from `book_creator`

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e6d0a7ef48329ae60bad83d92f199