### PR TITLE
feat: add Makefile with e2e test target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+.PHONY: test test-e2e
+
+test:
+pytest
+
+test-e2e:
+pytest -m integration tests/integration/
+


### PR DESCRIPTION
## Summary
- add Makefile with unit and e2e test targets

## Testing
- `pytest -q` *(fails: no input PDFs provided; Playwright download blocked)*

------
https://chatgpt.com/codex/tasks/task_e_684e797368648329aeb547e3661c6352