### PR TITLE
feat(cli): support multiple urls

### DIFF
--- a/tests/integration/test_end_to_end_cli.py
+++ b/tests/integration/test_end_to_end_cli.py
@@ -33,8 +33,6 @@ def playwright_setup():
         pytest.skip("Playwright not available")
 
 
-
-
 @pytest.mark.integration
 def test_end_to_end_success():
     env = os.environ.copy()
@@ -115,6 +113,70 @@ def test_output_pdf_validity():
             "-m",
             "web2pdfbook.cli",
             "https://httpbin.org/html",
+            str(output),
+            "--timeout",
+            "15000",
+        ],
+        capture_output=True,
+        text=True,
+        cwd=ROOT,
+        env=env,
+    )
+
+    assert result.returncode == 0, result.stderr
+    reader = PdfReader(str(output))
+    assert len(reader.pages) >= 1
+    output.unlink()
+
+
+@pytest.mark.integration
+def test_end_to_end_multiple_urls():
+    env = os.environ.copy()
+    docs_dir = ROOT / "docs"
+    docs_dir.mkdir(exist_ok=True)
+    output = docs_dir / "multi.pdf"
+    if output.exists():
+        output.unlink()
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "web2pdfbook.cli",
+            "https://httpbin.org/html",
+            "https://httpbin.org/html",
+            str(output),
+            "--timeout",
+            "15000",
+        ],
+        capture_output=True,
+        text=True,
+        cwd=ROOT,
+        env=env,
+    )
+
+    assert result.returncode == 0, result.stderr
+    reader = PdfReader(str(output))
+    assert len(reader.pages) >= 2
+    output.unlink()
+
+
+@pytest.mark.integration
+def test_end_to_end_mixed_urls():
+    env = os.environ.copy()
+    docs_dir = ROOT / "docs"
+    docs_dir.mkdir(exist_ok=True)
+    output = docs_dir / "mixed.pdf"
+    if output.exists():
+        output.unlink()
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "web2pdfbook.cli",
+            "https://httpbin.org/html",
+            "https://example.com/404",
             str(output),
             "--timeout",
             "15000",

--- a/tests/integration/test_end_to_end_cli.py
+++ b/tests/integration/test_end_to_end_cli.py
@@ -95,6 +95,7 @@ def test_end_to_end_broken_url():
     assert (
         "not found" in result.stderr.lower()
         or "no input pdfs provided" in result.stderr.lower()
+        or "no valid pdfs generated" in result.stderr.lower()
     ), f"Unexpected error: {result.stderr}"
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,9 +7,18 @@ from web2pdfbook.cli import main, parse_args
 
 def test_parse_args_valid():
     args = parse_args(["https://example.com", "out.pdf", "--timeout", "2000"])
-    assert args.url == "https://example.com"
+    assert args.urls == ["https://example.com"]
     assert args.output == "out.pdf"
     assert args.timeout == 2000
+
+
+def test_parse_args_multiple():
+    args = parse_args(
+        ["https://a.com", "https://b.com", "book.pdf", "--timeout", "1500"]
+    )
+    assert args.urls == ["https://a.com", "https://b.com"]
+    assert args.output == "book.pdf"
+    assert args.timeout == 1500
 
 
 @pytest.mark.parametrize(
@@ -30,4 +39,4 @@ def test_main_invokes_runner(mock_run, tmp_path):
     out = tmp_path / "book.pdf"
     argv = ["https://example.com", str(out), "--timeout", "2000"]
     assert main(argv) == 0
-    mock_run.assert_awaited_once_with("https://example.com", str(out), timeout=2000)
+    mock_run.assert_awaited_once_with(["https://example.com"], str(out), timeout=2000)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,17 +1,45 @@
 import asyncio
 from unittest.mock import AsyncMock, patch
 
+import pytest
+
 from web2pdfbook.book_creator import run
 
 
 @patch("web2pdfbook.book_creator.merge_documents")
-@patch("web2pdfbook.book_creator.render_to_pdf", new_callable=AsyncMock)
-@patch("web2pdfbook.book_creator.extract_links")
-def test_run_orchestrates(mock_extract, mock_render, mock_merge, tmp_path):
-    mock_extract.return_value.links = ["https://a", "https://b"]
+@patch("web2pdfbook.book_creator.create_book", new_callable=AsyncMock)
+def test_run_orchestrates(mock_create, mock_merge, tmp_path):
+    mock_create.side_effect = lambda url, dest, timeout, **kwargs: dest
     out = tmp_path / "book.pdf"
-    asyncio.run(run("https://base", str(out), 1234))
-    mock_extract.assert_called_once_with("https://base")
-    assert mock_render.await_count == 2
+    asyncio.run(run(["https://a", "https://b"], str(out), 1234))
+    assert mock_create.await_count == 2
     mock_merge.assert_called_once()
-    assert mock_merge.call_args.args[1] == str(out)
+    args = mock_merge.call_args.args
+    assert args[1] == str(out)
+    assert len(args[0]) == 2
+
+
+@patch("web2pdfbook.book_creator.logger")
+@patch("web2pdfbook.book_creator.merge_documents")
+@patch("web2pdfbook.book_creator.create_book", new_callable=AsyncMock)
+def test_run_partial_failures(mock_create, mock_merge, mock_logger, tmp_path):
+    async def succeed(url, dest, timeout, **kwargs):
+        return dest
+
+    mock_create.side_effect = [Exception("boom"), succeed]
+    out = tmp_path / "book.pdf"
+    asyncio.run(run(["bad", "good"], str(out), 1234))
+    mock_logger.warning.assert_called_once()
+    args = mock_merge.call_args.args
+    assert len(args[0]) == 1
+
+
+@patch(
+    "web2pdfbook.book_creator.create_book",
+    new_callable=AsyncMock,
+    side_effect=Exception("boom"),
+)
+def test_run_all_fail(mock_create, tmp_path):
+    out = tmp_path / "book.pdf"
+    with pytest.raises(RuntimeError):
+        asyncio.run(run(["bad"], str(out), 1234))

--- a/web2pdfbook/book_creator.py
+++ b/web2pdfbook/book_creator.py
@@ -1,13 +1,20 @@
 from __future__ import annotations
 
+import os
+import tempfile
+from typing import Iterable
+
 from .crawler import extract_links
+from .logger import get_logger
 from .merger import PyPDF2Merger, merge_documents
 from .renderer import PlaywrightRenderer, render_to_pdf
 from .usecase import create_book
 
+logger = get_logger(__name__)
 
-async def run(url: str, output: str, timeout: int = 15000) -> str:
-    """Crawl ``url`` and produce a merged PDF at ``output``."""
+
+async def run(urls: Iterable[str], output: str, timeout: int = 15000) -> str:
+    """Crawl ``urls`` and produce a merged PDF at ``output``."""
     renderer = PlaywrightRenderer()
 
     async def render_page(u: str, dest: str, t: int) -> bool:
@@ -16,11 +23,27 @@ async def run(url: str, output: str, timeout: int = 15000) -> str:
     def merge_pdfs(paths: list[str], dest: str) -> bool:
         return merge_documents(paths, dest, merger=PyPDF2Merger())
 
-    return await create_book(
-        url,
-        output,
-        timeout,
-        link_extractor=extract_links,
-        renderer=render_page,
-        merger=merge_pdfs,
-    )
+    pdf_paths: list[str] = []
+    with tempfile.TemporaryDirectory() as tmpdir:
+        for idx, url in enumerate(urls):
+            dest = os.path.join(tmpdir, f"site{idx}.pdf")
+            try:
+                await create_book(
+                    url,
+                    dest,
+                    timeout,
+                    link_extractor=extract_links,
+                    renderer=render_page,
+                    merger=merge_pdfs,
+                )
+                pdf_paths.append(dest)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("failed to process %s: %s", url, exc)
+
+        if not pdf_paths:
+            raise RuntimeError("no valid PDFs generated")
+
+        merge_pdfs(pdf_paths, output)
+
+    logger.info("written %s", output)
+    return output

--- a/web2pdfbook/cli.py
+++ b/web2pdfbook/cli.py
@@ -9,8 +9,11 @@ from .config import load_config
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Web2PDFBook CLI")
-    parser.add_argument("url", help="Base documentation URL")
-    parser.add_argument("output", help="Destination PDF file")
+    parser.add_argument(
+        "inputs",
+        nargs="+",
+        help="Base documentation URLs followed by the destination PDF file",
+    )
     parser.add_argument(
         "--timeout",
         type=int,
@@ -21,12 +24,19 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
-    return build_parser().parse_args(argv)
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if len(args.inputs) < 2:
+        parser.error("must provide at least one URL and an output file")
+    args.urls = args.inputs[:-1]
+    args.output = args.inputs[-1]
+    del args.inputs
+    return args
 
 
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
-    asyncio.run(run(args.url, args.output, timeout=args.timeout))
+    asyncio.run(run(args.urls, args.output, timeout=args.timeout))
     return 0
 
 

--- a/web2pdfbook/main.py
+++ b/web2pdfbook/main.py
@@ -1,14 +1,10 @@
 from __future__ import annotations
 
 import asyncio
-import sys
 
 from .book_creator import run
+from .cli import parse_args
 
 if __name__ == "__main__":  # pragma: no cover - manual invocation only
-    if len(sys.argv) < 3:
-        raise SystemExit("Usage: python main.py <url> <output> [timeout]")
-    url = sys.argv[1]
-    output = sys.argv[2]
-    timeout = int(sys.argv[3]) if len(sys.argv) > 3 else 15000
-    asyncio.run(run(url, output, timeout))
+    args = parse_args()
+    asyncio.run(run(args.urls, args.output, timeout=args.timeout))


### PR DESCRIPTION
## Summary
- update CLI parser to accept multiple URLs and an output file
- loop through URLs in `run()` and merge partial PDFs
- update main entrypoint to use the new parser
- extend unit tests for CLI and book creator
- add integration tests for multiple and mixed URLs

## Testing
- `ruff check web2pdfbook/book_creator.py web2pdfbook/cli.py web2pdfbook/main.py tests/test_cli.py tests/test_main.py tests/integration/test_end_to_end_cli.py`
- `ruff format web2pdfbook/book_creator.py web2pdfbook/cli.py web2pdfbook/main.py tests/test_cli.py tests/test_main.py tests/integration/test_end_to_end_cli.py`
- `mypy web2pdfbook/book_creator.py web2pdfbook/cli.py web2pdfbook/main.py tests/test_cli.py tests/test_main.py tests/integration/test_end_to_end_cli.py`
- `pytest -q -m "not integration"`

------
https://chatgpt.com/codex/tasks/task_e_684e85c2c91c8329ad4ef730839325bb