### PR TITLE
feat(crawler): add index link extraction

### DIFF
--- a/tests/usecase/test_extract_index_links.py
+++ b/tests/usecase/test_extract_index_links.py
@@ -1,0 +1,96 @@
+from unittest.mock import Mock, patch
+
+from web2pdfbook.crawler.usecase.extract_index_links import extract_index_links
+
+
+def test_extract_index_links_sitemap():
+    html_index = '<link rel="sitemap" href="/sitemap.xml">'
+    sitemap_xml = (
+        "<urlset>"
+        "<url><loc>https://example.com/index.html</loc></url>"
+        "<url><loc>https://example.com/page.html</loc></url>"
+        "<url><loc>https://other.com/out.html</loc></url>"
+        "<url><loc>https://example.com/img.png</loc></url>"
+        "</urlset>"
+    )
+
+    responses = {
+        "https://example.com/": Mock(
+            status_code=200, text=html_index, headers={"Content-Type": "text/html"}
+        ),
+        "https://example.com/sitemap.xml": Mock(
+            status_code=200,
+            text=sitemap_xml,
+            headers={"Content-Type": "text/xml"},
+        ),
+    }
+
+    def fake_get(url, *args, **kwargs):
+        return responses[url]
+
+    with patch(
+        "web2pdfbook.crawler.usecase.extract_index_links.requests.get",
+        side_effect=fake_get,
+    ):
+        result = extract_index_links("https://example.com/")
+
+    assert result.links == [
+        "https://example.com/index.html",
+        "https://example.com/page.html",
+    ]
+
+
+def test_extract_index_links_nav():
+    html_index = (
+        '<nav><a href="/index.html">idx</a></nav>'
+        '<div id="sidebar"><a href="/page.html">p</a><a href="/skip.png">i</a></div>'
+        '<div class="sphinxsidebar"><a href="https://example.com/foo.html">f</a></div>'
+        '<div role="navigation"><a href="http://example.com/bar.html">b</a></div>'
+        '<a href="https://other.com/out.html">o</a>'
+    )
+
+    responses = {
+        "https://example.com/": Mock(
+            status_code=200, text=html_index, headers={"Content-Type": "text/html"}
+        ),
+    }
+
+    def fake_get(url, *args, **kwargs):
+        return responses[url]
+
+    with patch(
+        "web2pdfbook.crawler.usecase.extract_index_links.requests.get",
+        side_effect=fake_get,
+    ):
+        result = extract_index_links("https://example.com/")
+
+    assert result.links == [
+        "https://example.com/index.html",
+        "https://example.com/page.html",
+        "https://example.com/foo.html",
+        "http://example.com/bar.html",
+    ]
+
+
+def test_extract_index_links_fallback():
+    responses = {
+        "https://example.com/": Mock(
+            status_code=200, text="<p>empty</p>", headers={"Content-Type": "text/html"}
+        ),
+    }
+
+    def fake_get(url, *args, **kwargs):
+        return responses[url]
+
+    with patch(
+        "web2pdfbook.crawler.usecase.extract_index_links.requests.get",
+        side_effect=fake_get,
+    ):
+        with patch(
+            "web2pdfbook.crawler.usecase.extract_index_links.extract_links"
+        ) as fallback:
+            fallback.return_value = Mock(links=["https://example.com/"])
+            result = extract_index_links("https://example.com/")
+            fallback.assert_called_once_with("https://example.com/")
+
+    assert result.links == ["https://example.com/"]

--- a/web2pdfbook/crawler/__init__.py
+++ b/web2pdfbook/crawler/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from .entity.crawl_result import CrawlResult
+from .usecase.extract_index_links import extract_index_links
 from .usecase.extract_links import extract_links
 
 
@@ -9,4 +10,4 @@ def get_all_links(base_url: str) -> list[str]:
     return extract_links(base_url).links
 
 
-__all__ = ["CrawlResult", "extract_links", "get_all_links"]
+__all__ = ["CrawlResult", "extract_links", "extract_index_links", "get_all_links"]

--- a/web2pdfbook/crawler/usecase/extract_index_links.py
+++ b/web2pdfbook/crawler/usecase/extract_index_links.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+from urllib.parse import urljoin, urlparse
+
+import requests
+from bs4 import BeautifulSoup
+from bs4.element import Tag
+
+from ..entity.crawl_result import CrawlResult
+from .extract_links import _is_html_url, extract_links
+
+
+def _fetch_html(url: str) -> str | None:
+    """Fetch ``url`` and return text if HTML, else ``None``."""
+    try:
+        resp = requests.get(url)
+        resp.raise_for_status()
+    except requests.RequestException:
+        return None
+    if "text/html" not in resp.headers.get("Content-Type", ""):
+        return None
+    return resp.text
+
+
+def extract_index_links(base_url: str) -> CrawlResult:
+    """Extract navigation links from ``base_url``."""
+    html = _fetch_html(base_url)
+    if not html:
+        return extract_links(base_url)
+
+    parsed_base = urlparse(base_url)
+    domain = parsed_base.netloc
+    soup = BeautifulSoup(html, "html.parser")
+
+    sitemap_link = soup.find("link", rel="sitemap")
+    links: list[str] = []
+
+    if isinstance(sitemap_link, Tag) and sitemap_link.has_attr("href"):
+        sitemap_url = urljoin(base_url, str(sitemap_link["href"]))
+        try:
+            resp = requests.get(sitemap_url)
+            resp.raise_for_status()
+        except requests.RequestException:
+            pass
+        else:
+            root = ET.fromstring(resp.text)
+            for loc in root.iterfind(".//loc"):
+                url = urljoin(sitemap_url, loc.text.strip())
+                parsed = urlparse(url)
+                if parsed.scheme not in {"http", "https"}:
+                    continue
+                if parsed.netloc != domain:
+                    continue
+                if not _is_html_url(url):
+                    continue
+                if url not in links:
+                    links.append(url)
+    else:
+        selectors = "nav, #sidebar, .sphinxsidebar, [role=navigation]"
+        for container in soup.select(selectors):
+            for tag in container.find_all("a", href=True):
+                if not isinstance(tag, Tag):
+                    continue
+                href = str(tag["href"])
+                if href.startswith("#"):
+                    continue
+                url = urljoin(base_url, href)
+                parsed = urlparse(url)
+                if parsed.scheme not in {"http", "https"}:
+                    continue
+                if parsed.netloc != domain:
+                    continue
+                if not _is_html_url(url):
+                    continue
+                if url not in links:
+                    links.append(url)
+
+    if not links:
+        return extract_links(base_url)
+
+    return CrawlResult(links)


### PR DESCRIPTION
## Summary
- support extracting links from sitemap or navigation sections
- expose `extract_index_links` from crawler
- test sitemap and nav parsing logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684eb40e736083298e377a400fa79c61