### PR TITLE
feat: add packaging metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ docs/
 .ruff_cache/
 .coverage
 htmlcov/
+dist/
+*.egg-info/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Web2PDFbook
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,7 @@
 name = "web2pdfbook"
 version = "0.1.0"
 description = "Convert website documentation into a PDF book"
+readme = "README.md"
 authors = [{name = "Your Name"}]
 license = "MIT"
 requires-python = ">=3.9"


### PR DESCRIPTION
## Summary
- add MIT license
- include README in pyproject
- ignore distribution files in git

## Testing
- `pip install -r requirements.txt`
- `pytest -m 'not integration' -q`
- `python -m build`
- `pip uninstall web2pdfbook -y`
- `pip install dist/web2pdfbook-0.1.0-py3-none-any.whl`
- `web2pdfbook --help`
- `web2pdfbook https://httpbin.org/html test_output.pdf --timeout 5000`

------
https://chatgpt.com/codex/tasks/task_e_684ecdd36fc08329a8e1f2a217b320cb