### PR TITLE
chore: update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ docs/
 htmlcov/
 dist/
 *.egg-info/
+.pypirc


### PR DESCRIPTION
## Summary
- ignore `.pypirc` files so that private publishing credentials aren't committed

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for requests, PyPDF2, and web2pdfbook)*

------
https://chatgpt.com/codex/tasks/task_e_684ed561a490832988f33544ff6da528