### PR TITLE
Add release publish script

### DIFF
--- a/release/publish.sh
+++ b/release/publish.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build wheel and sdist
+python -m build
+
+# Upload artifacts to repository (defaults to TestPyPI)
+REPOSITORY_URL="${REPOSITORY_URL:-https://test.pypi.org/legacy/}"
+
+twine upload --repository-url "$REPOSITORY_URL" dist/*
+
+# Verify installation from TestPyPI
+pip install -i https://test.pypi.org/simple --no-deps --force-reinstall web2pdfbook
+
+echo "\nPackage uploaded to $REPOSITORY_URL"
+echo "Install with: pip install -i https://test.pypi.org/simple web2pdfbook"


### PR DESCRIPTION
## Summary
- add `release/publish.sh` to automate building and uploading packages

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=$(pwd) pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684edacaa46883299eb3aa27719c4f5d