### PR TITLE
fix(test): register asyncio marker

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -3,3 +3,4 @@ addopts = -ra -q
 testpaths = tests
 markers =
     integration: marks integration tests requiring full stack
+    asyncio: mark tests that use asyncio


### PR DESCRIPTION
## Summary
- register the `asyncio` marker for pytest

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684edd2fdf588329b312d528f441361f