### PR TITLE
docs: clarify test setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 .PHONY: test test-e2e
 
 test:
-	pytest
+	pip install -r requirements.txt
+	python -m pytest
 
 test-e2e:
 	pytest -m integration tests/integration/

--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ web2pdfbook https://example.com output.pdf --timeout 20000 --use-index
 
 ## ✅ How to test
 
+Install dependencies first:
+
+```bash
+pip install -r requirements.txt
+```
+
 ```bash
 python -m coverage run -m pytest -q
 python -m coverage report


### PR DESCRIPTION
## Summary
- document installing requirements before running tests
- run dependency install from the Makefile test target

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_684eed444660832994f300223987dc22