### PR TITLE
Add packaging dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,19 @@ pip install -r requirements.txt
 python -m coverage run -m pytest -q
 python -m coverage report
 ```
+
+## 📦 How to release
+
+Install packaging dependencies:
+
+```bash
+pip install -r dev-requirements.txt
+```
+
+Build and upload the distribution (defaults to TestPyPI):
+
+```bash
+./release/publish.sh
+```
+
+This script runs `python -m build` and uploads with `twine`. Set `REPOSITORY_URL` to publish elsewhere.

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,3 +2,5 @@
 pre-commit
 ruff
 mypy
+build
+twine


### PR DESCRIPTION
## Summary
- add `build` and `twine` to development requirements
- document release procedure in README using the provided script

## Testing
- `python -m coverage run -m pytest -q`
- `python -m coverage report`

------
https://chatgpt.com/codex/tasks/task_e_684eefce53888329a3014402dcc3d3c2