### PR TITLE
fix(release): verify TestPyPI install

### DIFF
--- a/release/publish.sh
+++ b/release/publish.sh
@@ -11,6 +11,5 @@ twine upload --repository-url "$REPOSITORY_URL" dist/*
 
 # Verify installation from TestPyPI
 pip install -i https://test.pypi.org/simple --no-deps --force-reinstall web2pdfbook
-
 echo "\nPackage uploaded to $REPOSITORY_URL"
 echo "Install with: pip install -i https://test.pypi.org/simple web2pdfbook"


### PR DESCRIPTION
## Summary
- clean up publish script: keep TestPyPI install command on one line

## Testing
- `playwright install chromium`
- `python -m web2pdfbook.cli https://httpbin.org/html out.pdf --timeout 5000`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ef12543388329b62d6a88039da5d3