### PR TITLE
feat(cli): support --use-index

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,6 +10,7 @@ def test_parse_args_valid():
     assert args.urls == ["https://example.com"]
     assert args.output == "out.pdf"
     assert args.timeout == 2000
+    assert args.use_index is False
 
 
 def test_parse_args_multiple():
@@ -19,6 +20,7 @@ def test_parse_args_multiple():
     assert args.urls == ["https://a.com", "https://b.com"]
     assert args.output == "book.pdf"
     assert args.timeout == 1500
+    assert args.use_index is False
 
 
 @pytest.mark.parametrize(
@@ -33,10 +35,25 @@ def test_parse_args_missing(argv):
         parse_args(argv)
 
 
+def test_parse_args_use_index():
+    args = parse_args(
+        [
+            "https://example.com",
+            "out.pdf",
+            "--timeout",
+            "2000",
+            "--use-index",
+        ]
+    )
+    assert args.use_index is True
+
+
 @pytest.mark.asyncio
 @patch("web2pdfbook.cli.run", new_callable=AsyncMock)
 def test_main_invokes_runner(mock_run, tmp_path):
     out = tmp_path / "book.pdf"
-    argv = ["https://example.com", str(out), "--timeout", "2000"]
+    argv = ["https://example.com", str(out), "--timeout", "2000", "--use-index"]
     assert main(argv) == 0
-    mock_run.assert_awaited_once_with(["https://example.com"], str(out), timeout=2000)
+    mock_run.assert_awaited_once_with(
+        ["https://example.com"], str(out), timeout=2000, use_index=True
+    )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -11,12 +11,14 @@ from web2pdfbook.book_creator import run
 def test_run_orchestrates(mock_create, mock_merge, tmp_path):
     mock_create.side_effect = lambda url, dest, timeout, **kwargs: dest
     out = tmp_path / "book.pdf"
-    asyncio.run(run(["https://a", "https://b"], str(out), 1234))
+    asyncio.run(run(["https://a", "https://b"], str(out), 1234, use_index=True))
     assert mock_create.await_count == 2
     mock_merge.assert_called_once()
     args = mock_merge.call_args.args
     assert args[1] == str(out)
     assert len(args[0]) == 2
+    for call in mock_create.call_args_list:
+        assert call.kwargs.get("use_index_links") is True
 
 
 @patch("web2pdfbook.book_creator.logger")
@@ -32,6 +34,8 @@ def test_run_partial_failures(mock_create, mock_merge, mock_logger, tmp_path):
     mock_logger.warning.assert_called_once()
     args = mock_merge.call_args.args
     assert len(args[0]) == 1
+    for call in mock_create.call_args_list:
+        assert call.kwargs.get("use_index_links") is False
 
 
 @patch(
@@ -43,3 +47,4 @@ def test_run_all_fail(mock_create, tmp_path):
     out = tmp_path / "book.pdf"
     with pytest.raises(RuntimeError):
         asyncio.run(run(["bad"], str(out), 1234))
+    assert mock_create.call_args.kwargs.get("use_index_links") is False

--- a/web2pdfbook/book_creator.py
+++ b/web2pdfbook/book_creator.py
@@ -13,7 +13,9 @@ from .usecase import create_book
 logger = get_logger(__name__)
 
 
-async def run(urls: Iterable[str], output: str, timeout: int = 15000) -> str:
+async def run(
+    urls: Iterable[str], output: str, timeout: int = 15000, *, use_index: bool = False
+) -> str:
     """Crawl ``urls`` and produce a merged PDF at ``output``."""
     renderer = PlaywrightRenderer()
 
@@ -33,6 +35,7 @@ async def run(urls: Iterable[str], output: str, timeout: int = 15000) -> str:
                     dest,
                     timeout,
                     link_extractor=extract_links,
+                    use_index_links=use_index,
                     renderer=render_page,
                     merger=merge_pdfs,
                 )

--- a/web2pdfbook/cli.py
+++ b/web2pdfbook/cli.py
@@ -20,6 +20,11 @@ def build_parser() -> argparse.ArgumentParser:
         default=load_config().timeout,
         help="Render timeout in milliseconds",
     )
+    parser.add_argument(
+        "--use-index",
+        action="store_true",
+        help="Use navigation index to find pages",
+    )
     return parser
 
 
@@ -36,7 +41,9 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
-    asyncio.run(run(args.urls, args.output, timeout=args.timeout))
+    asyncio.run(
+        run(args.urls, args.output, timeout=args.timeout, use_index=args.use_index)
+    )
     return 0
 
 


### PR DESCRIPTION
## Summary
- add `--use-index` arg to cli
- wire through to main and runner
- use flag in run()
- test cli and run function for index flag

## Testing
- `ruff check web2pdfbook/cli.py web2pdfbook/book_creator.py tests/test_cli.py tests/test_main.py`
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_684ef3a834508329a34eacb1867c3a96