### PR TITLE
chore: organize imports

### DIFF
--- a/web2pdfbook/usecase/book_creator.py
+++ b/web2pdfbook/usecase/book_creator.py
@@ -5,8 +5,8 @@ import tempfile
 from typing import Awaitable, Callable
 from urllib.parse import urlparse
 
-from ..crawler.entity.crawl_result import CrawlResult
 from ..crawler import extract_index_links
+from ..crawler.entity.crawl_result import CrawlResult
 from ..logger import get_logger
 
 LinkExtractor = Callable[[str], CrawlResult]


### PR DESCRIPTION
## Summary
- fix import order in `book_creator`

## Testing
- `ruff check web2pdfbook/usecase/book_creator.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'web2pdfbook')*

------
https://chatgpt.com/codex/tasks/task_e_684ef703e250832997f5e518c8f024b5