### PR TITLE
Add pypirc template and update release docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ htmlcov/
 dist/
 *.egg-info/
 .pypirc
+!.pypirc

--- a/.pypirc
+++ b/.pypirc
@@ -1,0 +1,14 @@
+[distutils]
+index-servers =
+    pypi
+    testpypi
+
+[testpypi]
+repository = https://test.pypi.org/legacy/
+username = __token__
+password = <TESTPYPI_TOKEN>
+
+[pypi]
+repository = https://upload.pypi.org/legacy/
+username = __token__
+password = <PYPI_TOKEN>

--- a/README.md
+++ b/README.md
@@ -66,3 +66,7 @@ Build and upload the distribution (defaults to TestPyPI):
 ```
 
 This script runs `python -m build` and uploads with `twine`. Set `REPOSITORY_URL` to publish elsewhere.
+
+The repository contains a `.pypirc` template with placeholder credentials for
+TestPyPI and PyPI. Fill in your tokens (or copy it to `~/.pypirc`) so `twine`
+can authenticate during the upload.


### PR DESCRIPTION
## Summary
- track `.pypirc` by exempting it from gitignore
- add a `.pypirc` template with placeholder credentials
- document `.pypirc` usage in release instructions

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684eff9115ec8329bbccd2a3dede4f83