### PR TITLE
docs: add source install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ To test a pre-release from TestPyPI:
 pip install -i https://test.pypi.org/simple web2pdfbook
 ```
 
+If you cloned the repository and want to invoke `web2pdfbook` locally, install the dependencies first:
+
+```bash
+pip install -r requirements.txt
+```
+
 ## 🔄 How it works
 
 1. **Link crawling** – `crawler.extract_links()` retrieves all internal HTML links starting from the base URL.


### PR DESCRIPTION
## Summary
- document how to run `web2pdfbook` from a cloned repo

## Testing
- `pip install -r requirements.txt`
- `python -m coverage run -m pytest -q`
- `python -m coverage report`


------
https://chatgpt.com/codex/tasks/task_e_684f01314f34832989ba600df88908a4