### PR TITLE
fix(ci): allow workflow to update coverage badge

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -36,7 +38,11 @@ jobs:
         run: |
           git config --global user.name "github-actions"
           git config --global user.email "actions@github.com"
-          git add coverage.svg
-          git commit -m "chore: update coverage badge [skip ci]" || echo "No changes"
-          git push
+          if git diff --quiet HEAD coverage.svg; then
+            echo "No changes to commit"
+          else
+            git add coverage.svg
+            git commit -m "chore: update coverage badge [skip ci]"
+            git push
+          fi
 


### PR DESCRIPTION
## Summary
- grant write permissions to coverage job
- skip committing badge unless coverage.svg changed

## Testing
- `pre-commit run --files .github/workflows/python-ci.yml`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_684fa0763db48329b17b115b94bf43f5