### PR TITLE
feat(renderer): improve pdf rendering with css option

### DIFF
--- a/tests/integration/test_end_to_end_cli.py
+++ b/tests/integration/test_end_to_end_cli.py
@@ -3,9 +3,8 @@ import subprocess
 import sys
 from pathlib import Path
 
-import requests
-
 import pytest
+import requests
 from PyPDF2 import PdfReader
 
 ROOT = Path(__file__).resolve().parents[2]

--- a/tests/usecase/test_render_to_pdf.py
+++ b/tests/usecase/test_render_to_pdf.py
@@ -2,6 +2,7 @@ import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from PyPDF2 import PdfReader
 
 from web2pdfbook.renderer import PlaywrightRenderer, RendererError
 from web2pdfbook.renderer.entity.renderer import validate_params
@@ -15,7 +16,7 @@ from web2pdfbook.renderer.usecase.render_to_pdf import render_to_pdf
         ("https://example.com", "out.pdf", 15000),
     ],
 )
-def test_render_to_pdf_unit(mock_playwright, tmp_path, url, output, timeout):
+def test_render_to_pdf_unit_no_style(mock_playwright, tmp_path, url, output, timeout):
     page = AsyncMock()
     context = AsyncMock(new_page=AsyncMock(return_value=page))
     browser = AsyncMock(new_context=AsyncMock(return_value=context))
@@ -32,7 +33,47 @@ def test_render_to_pdf_unit(mock_playwright, tmp_path, url, output, timeout):
     )
     page.goto.assert_called_with(url, timeout=timeout)
     page.wait_for_load_state.assert_called_with("networkidle")
-    page.pdf.assert_called_with(path=str(dest))
+    page.add_style_tag.assert_not_called()
+    page.pdf.assert_called_with(
+        path=str(dest),
+        margin={"top": "0.5in", "bottom": "0.5in", "left": "0.5in", "right": "0.5in"},
+        scale=1.0,
+        print_background=True,
+    )
+
+
+@patch("web2pdfbook.renderer.adapter.playwright_renderer.async_playwright")
+def test_render_to_pdf_unit_with_style(mock_playwright, tmp_path):
+    page = AsyncMock()
+    context = AsyncMock(new_page=AsyncMock(return_value=page))
+    browser = AsyncMock(new_context=AsyncMock(return_value=context))
+    browser_type = AsyncMock(launch=AsyncMock(return_value=browser))
+    mock_playwright_cm = AsyncMock()
+    mock_playwright_cm.__aenter__.return_value = MagicMock(chromium=browser_type)
+    mock_playwright.return_value = mock_playwright_cm
+
+    dest = tmp_path / "styled.pdf"
+    renderer = PlaywrightRenderer()
+    style = "body { color: red; }"
+    assert (
+        asyncio.run(
+            render_to_pdf(
+                "https://example.com",
+                str(dest),
+                timeout=15000,
+                renderer=renderer,
+                style=style,
+            )
+        )
+        is True
+    )
+    page.add_style_tag.assert_called_with(content=style)
+    page.pdf.assert_called_with(
+        path=str(dest),
+        margin={"top": "0.5in", "bottom": "0.5in", "left": "0.5in", "right": "0.5in"},
+        scale=1.0,
+        print_background=True,
+    )
 
 
 @pytest.mark.parametrize(
@@ -75,7 +116,9 @@ def test_render_to_pdf_errors(mock_playwright, tmp_path, side_effect):
 
 
 class FailingRenderer:
-    async def render(self, url: str, output_path: str, timeout: int) -> None:
+    async def render(
+        self, url: str, output_path: str, timeout: int, *, style: str | None = None
+    ) -> None:
         raise RuntimeError("boom")
 
 
@@ -97,6 +140,68 @@ def test_validate_params_accepts_file_url(tmp_path):
     html.write_text("<p>ok</p>")
     file_url = html.as_uri()
     validate_params(file_url, str(tmp_path / "out.pdf"), 1501)
+
+
+def is_url_accessible(url: str) -> bool:
+    try:
+        import requests
+
+        resp = requests.get(url, timeout=5)
+        return resp.status_code == 200
+    except Exception:
+        return False
+
+
+def _ensure_playwright_installed() -> bool:
+    try:
+        import playwright  # noqa: F401
+    except Exception:
+        return False
+    import subprocess
+    import sys
+
+    result = subprocess.run(
+        [sys.executable, "-m", "playwright", "install", "chromium"],
+        capture_output=True,
+        text=True,
+    )
+    return result.returncode == 0
+
+
+@pytest.fixture(scope="session", autouse=True)
+def playwright_setup():
+    if not _ensure_playwright_installed():
+        pytest.skip("Playwright not available")
+
+
+@pytest.mark.integration
+def test_render_to_pdf_real_url_consistency(tmp_path):
+    url = "https://httpbin.org/html"
+    if not is_url_accessible(url):
+        pytest.skip("Test URL is not accessible")
+
+    out1 = tmp_path / "run1.pdf"
+    out2 = tmp_path / "run2.pdf"
+    renderer = PlaywrightRenderer()
+
+    assert (
+        asyncio.run(render_to_pdf(url, str(out1), timeout=20000, renderer=renderer))
+        is True
+    )
+    size1 = out1.stat().st_size
+    reader1 = PdfReader(str(out1))
+    pages1 = len(reader1.pages)
+
+    assert (
+        asyncio.run(render_to_pdf(url, str(out2), timeout=20000, renderer=renderer))
+        is True
+    )
+    size2 = out2.stat().st_size
+    reader2 = PdfReader(str(out2))
+    pages2 = len(reader2.pages)
+
+    assert pages1 == pages2 >= 1
+    assert size1 == size2
 
 
 @pytest.mark.skip("requires network and browser")

--- a/web2pdfbook/renderer/adapter/playwright_renderer.py
+++ b/web2pdfbook/renderer/adapter/playwright_renderer.py
@@ -17,7 +17,9 @@ class PlaywrightRenderer:
     def __init__(self, *, launch_args: list[str] | None = None) -> None:
         self.launch_args = launch_args or []
 
-    async def render(self, url: str, output_path: str, timeout: int) -> None:
+    async def render(
+        self, url: str, output_path: str, timeout: int, *, style: str | None = None
+    ) -> None:
         parsed = urlparse(url)
         args = list(self.launch_args)
         if parsed.scheme == "file":
@@ -28,11 +30,30 @@ class PlaywrightRenderer:
         try:
             async with async_playwright() as p:
                 browser = await p.chromium.launch(args=args)
-                context = await browser.new_context(ignore_https_errors=True)
+                context = await browser.new_context(
+                    ignore_https_errors=True,
+                    viewport={"width": 1280, "height": 800},
+                )
                 page = await context.new_page()
                 await page.goto(url, timeout=timeout)
                 await page.wait_for_load_state("networkidle")
-                await page.pdf(path=output_path)
+                if style:
+                    await page.add_style_tag(content=style)
+                    try:
+                        await page.evaluate("async () => await document.fonts.ready")
+                    except Exception:  # noqa: BLE001
+                        pass
+                await page.pdf(
+                    path=output_path,
+                    margin={
+                        "top": "0.5in",
+                        "bottom": "0.5in",
+                        "left": "0.5in",
+                        "right": "0.5in",
+                    },
+                    scale=1.0,
+                    print_background=True,
+                )
                 await browser.close()
         except Exception as exc:  # noqa: BLE001
             if parsed.scheme == "file":

--- a/web2pdfbook/renderer/usecase/render_to_pdf.py
+++ b/web2pdfbook/renderer/usecase/render_to_pdf.py
@@ -9,11 +9,12 @@ async def render_to_pdf(
     timeout: int,
     *,
     renderer: Renderer,
+    style: str | None = None,
 ) -> bool:
     """Validate inputs and delegate PDF rendering."""
     validate_params(url, output_path, timeout)
     try:
-        await renderer.render(url, output_path, timeout)
+        await renderer.render(url, output_path, timeout, style=style)
     except RendererError:
         raise
     except Exception as exc:  # noqa: BLE001


### PR DESCRIPTION
## Summary
- allow injecting CSS into Playwright renderer
- add stable viewport and PDF options
- expose optional `style` argument in `render_to_pdf`
- unit tests for style/no-style rendering
- sort imports in CLI integration tests for linting

## Testing
- `ruff check .`
- `black --check web2pdfbook/renderer/adapter/playwright_renderer.py web2pdfbook/renderer/usecase/render_to_pdf.py tests/usecase/test_render_to_pdf.py tests/integration/test_end_to_end_cli.py`
- `pytest tests/usecase/test_render_to_pdf.py::test_render_to_pdf_unit_no_style -q`
- `pytest tests/usecase/test_render_to_pdf.py::test_render_to_pdf_unit_with_style -q`
- `pytest -q` *(failed: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_685039d1dde0832994771061325462b2