### PR TITLE
fix: renderer param and PDF test

### DIFF
--- a/tests/usecase/test_render_to_pdf.py
+++ b/tests/usecase/test_render_to_pdf.py
@@ -75,7 +75,9 @@ def test_render_to_pdf_errors(mock_playwright, tmp_path, side_effect):
 
 
 class FailingRenderer:
-    async def render(self, url: str, output_path: str, timeout: int) -> None:
+    async def render(
+        self, url: str, output_path: str, timeout: int, *, style: str | None = None
+    ) -> None:
         raise RuntimeError("boom")
 
 

--- a/web2pdfbook/renderer/adapter/playwright_renderer.py
+++ b/web2pdfbook/renderer/adapter/playwright_renderer.py
@@ -17,7 +17,9 @@ class PlaywrightRenderer:
     def __init__(self, *, launch_args: list[str] | None = None) -> None:
         self.launch_args = launch_args or []
 
-    async def render(self, url: str, output_path: str, timeout: int) -> None:
+    async def render(
+        self, url: str, output_path: str, timeout: int, *, style: str | None = None
+    ) -> None:
         parsed = urlparse(url)
         args = list(self.launch_args)
         if parsed.scheme == "file":
@@ -32,6 +34,8 @@ class PlaywrightRenderer:
                 page = await context.new_page()
                 await page.goto(url, timeout=timeout)
                 await page.wait_for_load_state("networkidle")
+                if style:
+                    await page.add_style_tag(content=style)
                 await page.pdf(path=output_path)
                 await browser.close()
         except Exception as exc:  # noqa: BLE001

--- a/web2pdfbook/renderer/entity/renderer.py
+++ b/web2pdfbook/renderer/entity/renderer.py
@@ -9,7 +9,9 @@ class RendererError(Exception):
 
 
 class Renderer(Protocol):
-    async def render(self, url: str, output_path: str, timeout: int) -> None:
+    async def render(
+        self, url: str, output_path: str, timeout: int, *, style: str | None = None
+    ) -> None:
         """Render ``url`` into ``output_path`` as PDF."""
 
 


### PR DESCRIPTION
## Summary
- extend `Renderer` protocol with optional `style` parameter
- support style injection in `PlaywrightRenderer`
- update failing renderer test stub
- improve integration PDF validity test and skip when network or Playwright is unavailable

## Testing
- `pre-commit run --files web2pdfbook/renderer/entity/renderer.py web2pdfbook/renderer/adapter/playwright_renderer.py tests/usecase/test_render_to_pdf.py tests/integration/test_end_to_end_cli.py` *(fails: no valid PDFs generated due to blocked network)*


------
https://chatgpt.com/codex/tasks/task_e_68504a66fbf48329a58d6130774fda6f