### PR TITLE
feat(renderer): improve CSS and viewport

### DIFF
--- a/web2pdfbook/renderer/adapter/playwright_renderer.py
+++ b/web2pdfbook/renderer/adapter/playwright_renderer.py
@@ -11,11 +11,27 @@ from ..entity.renderer import RendererError
 logger = get_logger(__name__)
 
 
+DEFAULT_STYLE = """
+@page { margin: 1cm; }
+body { font-family: system-ui, sans-serif; }
+"""
+
+
 class PlaywrightRenderer:
     """Render pages using Playwright."""
 
-    def __init__(self, *, launch_args: list[str] | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        launch_args: list[str] | None = None,
+        css_path: str | None = None,
+        viewport_width: int = 1280,
+        viewport_height: int = 800,
+    ) -> None:
         self.launch_args = launch_args or []
+        self.css_path = css_path
+        self.viewport_width = viewport_width
+        self.viewport_height = viewport_height
 
     async def render(self, url: str, output_path: str, timeout: int) -> None:
         parsed = urlparse(url)
@@ -28,10 +44,21 @@ class PlaywrightRenderer:
         try:
             async with async_playwright() as p:
                 browser = await p.chromium.launch(args=args)
-                context = await browser.new_context(ignore_https_errors=True)
+                context = await browser.new_context(
+                    ignore_https_errors=True,
+                    viewport={
+                        "width": self.viewport_width,
+                        "height": self.viewport_height,
+                    },
+                )
                 page = await context.new_page()
                 await page.goto(url, timeout=timeout)
                 await page.wait_for_load_state("networkidle")
+                await page.emulate_media(media="screen")
+                await page.add_style_tag(content=DEFAULT_STYLE)
+                if self.css_path:
+                    css_file = str(Path(self.css_path).resolve())
+                    await page.add_style_tag(path=css_file)
                 await page.pdf(path=output_path)
                 await browser.close()
         except Exception as exc:  # noqa: BLE001


### PR DESCRIPTION
## Summary
- inject custom CSS and default page styling in Playwright renderer
- set viewport and emulate screen media
- test CSS injection and new calls

## Testing
- `mypy web2pdfbook/renderer/adapter/playwright_renderer.py tests/usecase/test_render_to_pdf.py`
- `pytest -k 'not integration' -q`

------
https://chatgpt.com/codex/tasks/task_e_685148a2c4788329a418bedec77d1223