### PR TITLE
feat(renderer): refine Playwright viewport and CSS

### DIFF
--- a/web2pdfbook/renderer/adapter/playwright_renderer.py
+++ b/web2pdfbook/renderer/adapter/playwright_renderer.py
@@ -13,13 +13,30 @@ logger = get_logger(__name__)
 
 DEFAULT_STYLE = """
 @page { margin: 1cm; }
+@import url('https://fonts.googleapis.com/css2?family=Inter&display=swap');
 @media print {
   body {
-    margin: 0;
+    margin: 0 auto;
     padding: 0;
-    font-family: system-ui, sans-serif;
+    max-width: 100%;
+    font-family: 'Inter', system-ui, sans-serif;
     font-size: 12pt;
     -webkit-font-smoothing: antialiased;
+  }
+
+  *, *::before, *::after {
+    animation: none !important;
+    transition: none !important;
+  }
+
+  h1,
+  h2,
+  h3,
+  p,
+  ul,
+  ol,
+  section {
+    page-break-inside: avoid;
   }
 }
 """
@@ -28,17 +45,12 @@ SUPPRESS_STYLE = """
 @media print {
   nav,
   .navbar,
-  .footer,
-  .header,
   .sidebar,
-  [data-testid="search"] {
+  footer,
+  form,
+  .search,
+  button {
     display: none !important;
-  }
-
-  section,
-  article,
-  div {
-    page-break-inside: avoid;
   }
 }
 """
@@ -52,8 +64,8 @@ class PlaywrightRenderer:
         *,
         launch_args: list[str] | None = None,
         css_path: str | None = None,
-        viewport_width: int = 1280,
-        viewport_height: int = 800,
+        viewport_width: int = 1024,
+        viewport_height: int = 1366,
     ) -> None:
         self.launch_args = launch_args or []
         self.css_path = css_path


### PR DESCRIPTION
## Summary
- refine PlaywrightRenderer viewport defaults for A4
- inject cleanup styles for clearer PDF output

## Testing
- `ruff check --fix web2pdfbook/renderer/adapter/playwright_renderer.py tests/usecase/test_render_to_pdf.py`
- `mypy web2pdfbook/renderer/adapter/playwright_renderer.py tests/usecase/test_render_to_pdf.py`
- `python -m coverage run -m pytest -q` *(fails: RuntimeError no valid PDFs generated)*

------
https://chatgpt.com/codex/tasks/task_e_68515d22917c8329a81e73282bd8ccce